### PR TITLE
Decrement ost status on heuristics that fail duration requirement

### DIFF
--- a/TransShiftMex/ost.cpp
+++ b/TransShiftMex/ost.cpp
@@ -455,7 +455,7 @@ int OST_TAB::osTrack(const int stat, const int data_counter, const int frame_cou
 					}
 				}
 				else {
-					stat_out = stat + 1;
+					stat_out = stat - 1;
 				}
 			}
 
@@ -501,7 +501,7 @@ int OST_TAB::osTrack(const int stat, const int data_counter, const int frame_cou
 					}
 				}
 				else {
-					stat_out = stat + 1;
+					stat_out = stat - 1;
 				}
 			}
 			else {


### PR DESCRIPTION
Hi Shanqing, I'm working with Carrie Niziolek at UW-Madison on these changes. As I believe Carrie mentioned in an email to you, this is the first of a few changes we're hoping to merge.

This pull request specifically addresses NEG_INTENSITY_SLOPE_STRETCH_SPAN and INTENSITY_RATIO_RISE. Earlier this year, our lab made this change, compiled, and ran an experiment with the new .mex file. We used these two heuristics for that experiment and can confirm that this fix works.